### PR TITLE
Update Google Maps api key to Huracan Foundation's

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
-google_maps_api_key: AIzaSyC_-NGDykCYRs7Hyz8pOkSkO4bDsDSAKtk
+google_maps_api_key: AIzaSyDWzCEih9viVsIsPHLM-BtUQJTilr5GBi8
 
 # Build settings
 # Exclude from processing.


### PR DESCRIPTION
The Huracan Fopundation Google Maps API key should now be working, so updating it again (I had been using my personal API key in the meantime).

Note: I had set up the key with Mary to ensure it's restricted to use on this project's GitHub pages URL, so it should be safe to make public.  The key has to be included in the source code of the page to load the google maps API anyway, so it's never going to be a private key.